### PR TITLE
Fixed link to documentation

### DIFF
--- a/index.html
+++ b/index.html
@@ -67,7 +67,7 @@
             </a>
         </li>
         <li class="b-vert__item">
-            <a class="b-vert__title" href="https://docs.qameta.io/allure/latest/">
+            <a class="b-vert__title" href="https://docs.qameta.io/allure">
                 <div class="b-vert__icon octicon octicon-repo"></div>
                 Documentation
             </a>


### PR DESCRIPTION
Fixed link pointing to the latest subpage on https://docs.qameta.io/allure which returns a 404